### PR TITLE
Allow use of unicode lists

### DIFF
--- a/lib/Lingua/EN/Pseudolocalize.pm
+++ b/lib/Lingua/EN/Pseudolocalize.pm
@@ -1,48 +1,156 @@
 package Lingua::EN::Pseudolocalize;
-use strict; use warnings;
+use strict;
+use warnings;
+use 5.008;
 use Sub::Exporter::Simple qw/convert deconvert/;
 use charnames ':full';
 
 # ABSTRACT: Test Unicode support by pretending to speak a different language.
 
-my $lookup = {
-   'th' => "\N{LATIN SMALL LETTER TH WITH STRIKETHROUGH}",
-   'ts' => "\N{LATIN SMALL LETTER TS DIGRAPH}",
-   'st' => "\N{LATIN SMALL LIGATURE ST}",
-   'a' =>  "\N{LATIN SMALL LETTER A WITH HOOK ABOVE}",
-   'b' =>  "\N{LATIN SMALL LETTER B WITH MIDDLE TILDE}",
-   'd' =>  "\N{LATIN SMALL LETTER D WITH CURL}",
-   'e' =>  "\N{LATIN SMALL LETTER E WITH INVERTED BREVE}",
-   'i' =>  "\N{LATIN SMALL LETTER I WITH DIAERESIS AND ACUTE}",
-   'o' =>  "\N{LATIN SMALL LETTER O WITH DOT ABOVE}",
-   'u' =>  "\N{LATIN SMALL LETTER U WITH HORN AND HOOK ABOVE}",
-   'A' =>  "\N{LATIN CAPITAL LETTER A WITH RING BELOW}",
-   'E' =>  "\N{LATIN CAPITAL LETTER E WITH TILDE BELOW}",
-   'I' =>  "\N{LATIN CAPITAL LETTER I WITH INVERTED BREVE}",
-   'O' =>  "\N{LATIN CAPITAL LETTER O WITH STROKE AND ACUTE}",
-   'U' =>  "\N{LATIN CAPITAL LETTER U WITH DIAERESIS BELOW}",
-   'T' =>  "\N{LATIN CAPITAL LETTER T WITH HOOK}",
-   'N' =>  "\N{LATIN CAPITAL LETTER N WITH ACUTE}",
-   'S' =>  "\N{LATIN CAPITAL LETTER S WITH COMMA BELOW}",
-   'H' =>  "\N{LATIN CAPITAL LETTER H WITH DIAERESIS}",
-   'R' =>  "\N{LATIN CAPITAL LETTER R WITH DOT BELOW AND MACRON}",
-   'D' =>  "\N{LATIN CAPITAL LETTER D WITH STROKE}",
-   'L' =>  "\N{LATIN CAPITAL LETTER L WITH MIDDLE DOT}",
+our $lookup = {
+    'A' => [
+        "\N{LATIN CAPITAL LETTER A WITH GRAVE}",
+        "\N{LATIN CAPITAL LETTER A WITH ACUTE}",
+        "\N{LATIN CAPITAL LETTER A WITH CIRCUMFLEX}",
+        "\N{LATIN CAPITAL LETTER A WITH TILDE}",
+        "\N{LATIN CAPITAL LETTER A WITH DIAERESIS}",
+        "\N{LATIN CAPITAL LETTER A WITH RING ABOVE}",
+        "\N{LATIN CAPITAL LETTER A WITH RING BELOW}",
+    ],
+    'C' => [ "\N{LATIN CAPITAL LETTER C WITH CEDILLA}", ],
+    'D' => [ "\N{LATIN CAPITAL LETTER D WITH STROKE}", ],
+    'E' => [
+        "\N{LATIN CAPITAL LETTER E WITH GRAVE}",
+        "\N{LATIN CAPITAL LETTER E WITH ACUTE}",
+        "\N{LATIN CAPITAL LETTER E WITH CIRCUMFLEX}",
+        "\N{LATIN CAPITAL LETTER E WITH DIAERESIS}",
+        "\N{LATIN CAPITAL LETTER E WITH TILDE BELOW}",
+    ],
+    'H' => [ "\N{LATIN CAPITAL LETTER H WITH DIAERESIS}", ],
+    'I' => [
+        "\N{LATIN CAPITAL LETTER I WITH GRAVE}",
+        "\N{LATIN CAPITAL LETTER I WITH ACUTE}",
+        "\N{LATIN CAPITAL LETTER I WITH CIRCUMFLEX}",
+        "\N{LATIN CAPITAL LETTER I WITH DIAERESIS}",
+        "\N{LATIN CAPITAL LETTER I WITH INVERTED BREVE}",
+    ],
+    'L' => [ "\N{LATIN CAPITAL LETTER L WITH MIDDLE DOT}", ],
+    'N' => [
+        "\N{LATIN CAPITAL LETTER N WITH TILDE}",
+        "\N{LATIN CAPITAL LETTER N WITH ACUTE}",
+    ],
+    'O' => [
+        "\N{LATIN CAPITAL LETTER O WITH GRAVE}",
+        "\N{LATIN CAPITAL LETTER O WITH ACUTE}",
+        "\N{LATIN CAPITAL LETTER O WITH CIRCUMFLEX}",
+        "\N{LATIN CAPITAL LETTER O WITH TILDE}",
+        "\N{LATIN CAPITAL LETTER O WITH DIAERESIS}",
+        "\N{LATIN CAPITAL LETTER O WITH STROKE}",
+        "\N{LATIN CAPITAL LETTER O WITH STROKE AND ACUTE}",
+    ],
+    'R' => [ "\N{LATIN CAPITAL LETTER R WITH DOT BELOW AND MACRON}", ],
+    'S' => [ "\N{LATIN CAPITAL LETTER S WITH COMMA BELOW}", ],
+    'T' => [ "\N{LATIN CAPITAL LETTER T WITH HOOK}", ],
+    'U' => [
+        "\N{LATIN CAPITAL LETTER U WITH GRAVE}",
+        "\N{LATIN CAPITAL LETTER U WITH ACUTE}",
+        "\N{LATIN CAPITAL LETTER U WITH CIRCUMFLEX}",
+        "\N{LATIN CAPITAL LETTER U WITH DIAERESIS}",
+        "\N{LATIN CAPITAL LETTER U WITH DIAERESIS BELOW}",
+    ],
+    'Y' => [ "\N{LATIN CAPITAL LETTER Y WITH ACUTE}", ],
+
+    'a' => [
+        "\N{LATIN SMALL LETTER A WITH GRAVE}",
+        "\N{LATIN SMALL LETTER A WITH ACUTE}",
+        "\N{LATIN SMALL LETTER A WITH CIRCUMFLEX}",
+        "\N{LATIN SMALL LETTER A WITH TILDE}",
+        "\N{LATIN SMALL LETTER A WITH DIAERESIS}",
+        "\N{LATIN SMALL LETTER A WITH RING ABOVE}",
+        "\N{LATIN SMALL LETTER A WITH HOOK ABOVE}",
+    ],
+    'b' => [ "\N{LATIN SMALL LETTER B WITH MIDDLE TILDE}", ],
+    'c' => [ "\N{LATIN SMALL LETTER C WITH CEDILLA}", ],
+    'd' => [ "\N{LATIN SMALL LETTER D WITH CURL}", ],
+    'e' => [
+        "\N{LATIN SMALL LETTER E WITH GRAVE}",
+        "\N{LATIN SMALL LETTER E WITH ACUTE}",
+        "\N{LATIN SMALL LETTER E WITH CIRCUMFLEX}",
+        "\N{LATIN SMALL LETTER E WITH DIAERESIS}",
+        "\N{LATIN SMALL LETTER E WITH INVERTED BREVE}",
+    ],
+    'i' => [
+        "\N{LATIN SMALL LETTER I WITH GRAVE}",
+        "\N{LATIN SMALL LETTER I WITH ACUTE}",
+        "\N{LATIN SMALL LETTER I WITH CIRCUMFLEX}",
+        "\N{LATIN SMALL LETTER I WITH DIAERESIS}",
+        "\N{LATIN SMALL LETTER I WITH DIAERESIS AND ACUTE}",
+    ],
+    'n' => [ "\N{LATIN SMALL LETTER N WITH TILDE}", ],
+    'o' => [
+        "\N{LATIN SMALL LETTER O WITH GRAVE}",
+        "\N{LATIN SMALL LETTER O WITH ACUTE}",
+        "\N{LATIN SMALL LETTER O WITH CIRCUMFLEX}",
+        "\N{LATIN SMALL LETTER O WITH TILDE}",
+        "\N{LATIN SMALL LETTER O WITH DIAERESIS}",
+        "\N{LATIN SMALL LETTER O WITH STROKE}",
+        "\N{LATIN SMALL LETTER O WITH DOT ABOVE}",
+    ],
+    'st' => [ "\N{LATIN SMALL LIGATURE ST}", ],
+    'th' => [ "\N{LATIN SMALL LETTER TH WITH STRIKETHROUGH}", ],
+    'ts' => [ "\N{LATIN SMALL LETTER TS DIGRAPH}", ],
+    'u'  => [
+        "\N{LATIN SMALL LETTER U WITH GRAVE}",
+        "\N{LATIN SMALL LETTER U WITH ACUTE}",
+        "\N{LATIN SMALL LETTER U WITH CIRCUMFLEX}",
+        "\N{LATIN SMALL LETTER U WITH DIAERESIS}",
+        "\N{LATIN SMALL LETTER U WITH HORN AND HOOK ABOVE}",
+    ],
+    'y' => [
+        "\N{LATIN SMALL LETTER Y WITH ACUTE}",
+        "\N{LATIN SMALL LETTER Y WITH DIAERESIS}",
+    ],
 };
 
 sub convert {
    my $str = shift;
-   $str =~ s/$_/$lookup->{$_}/g for keys %$lookup;
+
+    for my $key ( keys %$lookup ) {
+        my @list = @{ $lookup->{$key} };
+        my $char = $list[ int rand @list ];
+        $str =~ s/\Q$key/$char/g;
+    }
+
    return $str
 }
 
 sub deconvert {
    my $str = shift;
-   $str =~ s/$lookup->{$_}/$_/g for keys %$lookup;
+
+    for my $key ( keys %$lookup ) {
+        for my $char ( @{ $lookup->{$key} } ) {
+            $str =~ s/$char/$key/g;
+        }
+    }
+
    return $str
 }
 
 1;
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+Lingua::EN::Pseudolocalize - Test Unicode support by pretending to speak a different language.
+
+=head1 VERSION
+
+version 0.004
 
 =head1 SYNOPSIS
 
@@ -80,3 +188,15 @@ Returns: the converted string
 
 =back
 
+=head1 AUTHOR
+
+Wes Malone <wesm@cpan.org>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2015 by Wes Malone <wesm@cpan.org>.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/lib/Lingua/EN/Pseudolocalize.pm
+++ b/lib/Lingua/EN/Pseudolocalize.pm
@@ -138,20 +138,6 @@ sub deconvert {
 
 1;
 
-__END__
-
-=pod
-
-=encoding UTF-8
-
-=head1 NAME
-
-Lingua::EN::Pseudolocalize - Test Unicode support by pretending to speak a different language.
-
-=head1 VERSION
-
-version 0.004
-
 =head1 SYNOPSIS
 
     use Lingua::EN::Pseudolocalize qw( convert deconvert );
@@ -188,15 +174,3 @@ Returns: the converted string
 
 =back
 
-=head1 AUTHOR
-
-Wes Malone <wesm@cpan.org>
-
-=head1 COPYRIGHT AND LICENSE
-
-This software is copyright (c) 2015 by Wes Malone <wesm@cpan.org>.
-
-This is free software; you can redistribute it and/or modify it under
-the same terms as the Perl 5 programming language system itself.
-
-=cut


### PR DESCRIPTION
Hi Wes.

I really like your module but need to it choose from a range of unicode characters instead of just one.

So I converted the lookup to arrayrefs and then rewrote how the convert() and deconvert() routines do their thing.

Also, I made the lookup hashref an "our" variable (instead of my) so that the lookup can be modified from outside the module.  This is handy if a user wants to only use Unicode Extended-C chars for instance.

And since the interface hasn't changed, the t/00-convert.t test passes without modification. :-)

Thanks,
Gene Boggs (https://metacpan.org/author/GENE)